### PR TITLE
지역별 식당 - 경인 페이지

### DIFF
--- a/src/main/java/com/restaurant/controller/MainController.java
+++ b/src/main/java/com/restaurant/controller/MainController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
 import java.util.Optional;
 
 @Controller
@@ -96,6 +97,36 @@ public class MainController {
         model.addAttribute("maxPage", 5);
         model.addAttribute("deleteSuccess", deleteSuccess);
         return "region/seoulPage";
+    }
+
+    @GetMapping(value = "/rest/gyeongin")
+    public String GyeonginMain(RestSearchDto restSearchDto, @RequestParam(required = false)List<String> regions,Optional<Integer> page, @RequestParam(required = false) Boolean deleteSuccess, Model model){
+        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 16);
+
+        Page<MainRestDto> rests = restService.getGyeonginRestPage(regions,pageable);
+
+        model.addAttribute("rests", rests);
+        model.addAttribute("restSearchDto", restSearchDto);
+        model.addAttribute("maxPage", 5);
+        model.addAttribute("deleteSuccess", deleteSuccess);
+        return "region/gyeonginPage";
+    }
+    @GetMapping(value = "/rest/gyeongin/region")
+    public String GyeonginRegion(RestSearchDto restSearchDto, Optional<Integer> page, @RequestParam(required = false) Boolean deleteSuccess, Model model) {
+        Pageable pageable = PageRequest.of(page.isPresent() ? page.get() : 0, 16);
+        Page<MainRestDto> rests;
+
+        if(restSearchDto.getRegion() != null && !restSearchDto.getRegion().isEmpty()) {
+            rests = restService.getRegionRestPage(restSearchDto.getRegion(), pageable);
+        } else {
+            rests = restService.getMainRestPage(restSearchDto, pageable);
+        }
+
+        model.addAttribute("rests", rests);
+        model.addAttribute("restSearchDto", restSearchDto);
+        model.addAttribute("maxPage", 5);
+        model.addAttribute("deleteSuccess", deleteSuccess);
+        return "region/gyeonginPage";
     }
 
 }

--- a/src/main/java/com/restaurant/repository/RestRepositoryCustom.java
+++ b/src/main/java/com/restaurant/repository/RestRepositoryCustom.java
@@ -6,10 +6,13 @@ import com.restaurant.entity.Rest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface RestRepositoryCustom {
     Page<Rest> getAdminRestPage(RestSearchDto restSearchDto, Pageable pageable);
     Page<MainRestDto> getMainRestPage(RestSearchDto restSearchDto, Pageable pageable);
     Page<MainRestDto> getCategoryRestPage(String category,Pageable pageable);
     Page<MainRestDto> findByAddressStartingWithSeoul(Pageable pageable);
     Page<MainRestDto> getRegionRestPage(String region,Pageable pageable);
+    Page<MainRestDto> findByAddressStartingWithGyeongin(List<String> regions,Pageable pageable);
 }

--- a/src/main/java/com/restaurant/service/RestService.java
+++ b/src/main/java/com/restaurant/service/RestService.java
@@ -125,5 +125,9 @@ public class RestService {
     public Page<MainRestDto> getRegionRestPage(String region, Pageable pageable){
         return restRepository.getRegionRestPage(region, pageable);
     }
+    @Transactional(readOnly = true)
+    public Page<MainRestDto> getGyeonginRestPage(List<String> regions, Pageable pageable){
+        return restRepository.findByAddressStartingWithGyeongin(regions,pageable);
+    }
 
 }

--- a/src/main/resources/templates/region/gyeonginPage.html
+++ b/src/main/resources/templates/region/gyeonginPage.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .carousel-inner > .item {
+            height: 350px;
+        }
+        .margin{
+            margin-bottom:30px;
+        }
+
+        .card-text{
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+        a:hover{
+            text-decoration:none;
+        }
+        .center{
+            text-align:center;
+        }
+
+
+        .nav-item > a {
+            text-align: center;  /* 텍스트 중앙 정렬 */
+        }
+
+    </style>
+</th:block>
+
+<th:block layout:fragment="script">
+    <script th:inline="javascript">
+    </script>
+</th:block>
+
+<div layout:fragment="content">
+    <h2>어디로 갈까요?</h2>
+
+    <!-- 카테고리 메뉴 -->
+    <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse flex-column" id="navbarNav">
+            <div class="d-flex justify-content-around mb-2">
+                <a class="nav-link" href="/rest/gyeongin">경기/인천 전체</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=성남시,하남시,광주시">성남/하남/광주</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=군포시,안양시,의왕시,과천시">군포/안양/의왕/과천</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=수원시,용인시,안성시">수원/용인/안성</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=안산시,시흥시">안산/시흥</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=가평군,양평군">가평/양평</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=미추홀구,연수구">미추홀/연수</a>
+                <a class="nav-link" href="/rest/gyeongin?regions=부평구,계양구">부평/계양</a>
+                <div class="dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="seoulDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">그 외</a>
+                    <div class="dropdown-menu" aria-labelledby="seoulDropdown">
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=부천시,광명시">부천/광명</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=화성시,평택시,오산시">화성/평택/오산</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=연천군,동두천시,포천시">연쳔/동두천/포천</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=파주시,고양시,김포시">파주/고양/김포</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=구리시,남양주시">구리/남양주</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=여주시,이천시">여주/이천</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=의정부시,양주시">의정부/양주</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=중구,옹진군">중구/옹진군</a>
+                        <a class="dropdown-item" href="/rest/gyeongin?regions=동구,서구">동구/서구</a>
+                        <a class="dropdown-item" href="/rest/gyeongin/region?region=남동구">남동구</a>
+                        <a class="dropdown-item" href="/rest/gyeongin/region?region=강화군">강화군</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+
+    <input type="hidden" name="searchQuery" th:value="${restSearchDto.searchQuery}">
+    <div th:if="${not #strings.isEmpty(restSearchDto.searchQuery)}" class="center">
+        <p class="h3 font-weight-bold" th:text="${restSearchDto.searchQuery} + '검색 결과'"></p>
+    </div>
+
+    <div class="row">
+        <th:block th:each="rest, status: ${rests.getContent()}">
+            <div class="col-md-4 margin">
+                <div class="card">
+                    <a th:href="'/rest/' +${rest.id}" class="text-dark">
+                        <img th:src="${rest.imgUrl}" class="card-img-top" th:alt="${rest.restNm}" height="400">
+                        <div class="card-body">
+                            <h4 class="card-title"><[[${rest.category}]]> [[${rest.restNm}]]</h4>
+                            <p class="card-text">번호: [[${rest.restPhone}]]</p>
+                            <p class="card-text">[[${rest.address}]]</p>
+                            <h3 class="card-title">[[${rest.introduction}]]</h3>
+                        </div>
+                    </a>
+                </div>
+            </div>
+        </th:block>
+    </div>
+
+    <div th:with="start=${(rests.number/maxPage)*maxPage + 1}, end=(${(rests.totalPages == 0) ? 1 : (start + (maxPage - 1) < rests.totalPages ? start + (maxPage - 1) : rests.totalPages)})" >
+        <ul class="pagination justify-content-center">
+
+            <li class="page-item" th:classappend="${rests.number eq 0}?'disabled':''">
+                <a th:href="@{'/' + '?searchQuery=' + ${restSearchDto.searchQuery} + '&page=' + ${rests.number-1}}" aria-label='Previous' class="page-link">
+                    <span aria-hidden='true'>Previous</span>
+                </a>
+            </li>
+
+            <li class="page-item" th:each="page: ${#numbers.sequence(start, end)}" th:classappend="${rests.number eq page-1}?'active':''">
+                <a th:href="@{'/' +'?searchQuery=' + ${restSearchDto.searchQuery} + '&page=' + ${page-1}}" th:inline="text" class="page-link">[[${page}]]</a>
+            </li>
+
+            <li class="page-item" th:classappend="${rests.number+1 ge rests.totalPages}?'disabled':''">
+                <a th:href="@{'/' +'?searchQuery=' + ${restSearchDto.searchQuery} + '&page=' + ${rests.number+1}}" aria-label='Next' class="page-link">
+                    <span aria-hidden='true'>Next</span>
+                </a>
+            </li>
+
+        </ul>
+    </div>
+
+</div>

--- a/src/main/resources/templates/regionMain.html
+++ b/src/main/resources/templates/regionMain.html
@@ -57,7 +57,7 @@
             <img src="" alt="서울 이미지">
             <p>서울</p>
         </div>
-        <div class="city-card" onclick="location.href='busan'">
+        <div class="city-card" onclick="location.href='gyeongin'">
             <img src="" alt="경인 이미지">
             <p>경기/인천</p>
         </div>


### PR DESCRIPTION
1. 지역별 식당 - 경인 페이지를 구현하며,
단일 region들을 List<String> regions 형식으로 받아 쉼표로 나누었다. 이 방법을 통하여 여러 지역의 식당 데이터들 (region = "수원시"와 region="용인시")을 동시에 가져올 수 있다.